### PR TITLE
Change travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,12 @@ language: ruby
 dist: trusty
 os:
   - linux
-  - osx
+#  - osx
 
 rvm:
   - 2.3.3
-  - 2.4.0
+  - 2.4.2
+  - ruby-head
 
 services:
   - mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ rvm:
   - 2.4.2
   - ruby-head
 
+matrix:
+  fast_finish: true
+  allow_failures:
+    - rvm: ruby-head
+
 services:
   - mysql
 

--- a/arg_scanner/arg_scanner.gemspec
+++ b/arg_scanner/arg_scanner.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rake-compiler"
-  spec.add_development_dependency "debase-ruby_core_source", "~> 0.9.6"
+  spec.add_development_dependency "debase-ruby_core_source", ">= 0.10.0"
 end


### PR DESCRIPTION
A kind of workaround for https://github.com/JetBrains/ruby-type-inference/issues/9

Using more modern ruby_core_source is required to test against ruby-head: https://github.com/os97673/debase-ruby_core_source/pull/9