### PR TITLE
Use `require_relative` in starter.rb

### DIFF
--- a/arg_scanner/lib/arg_scanner/starter.rb
+++ b/arg_scanner/lib/arg_scanner/starter.rb
@@ -1,4 +1,5 @@
-require 'arg_scanner'
+require_relative 'arg_scanner'
+require_relative 'type_tracker'
 
 # instantiating type tracker will enable calls tracing and sending the data
 ArgScanner::TypeTracker.instance


### PR DESCRIPTION
Use relative require in starter.rb to successfully handle an execution of subprocess in a different context (like rake).