### PR TITLE
Bobko/included modules to ancestors

### DIFF
--- a/arg_scanner/lib/arg_scanner/state_tracker.rb
+++ b/arg_scanner/lib/arg_scanner/state_tracker.rb
@@ -75,8 +75,8 @@ module ArgScanner
       ret = {
         :name => mod.to_s,
         :type => mod.class.to_s,
-        :singleton_class_included => mod.singleton_class.included_modules,
-        :included => mod.included_modules,
+        :singleton_class_ancestors => mod.singleton_class.ancestors,
+        :ancestors => mod.ancestors,
         :class_methods => mod.methods(false).map {|method| method_to_json(mod.method(method))}.compact,
         :instance_methods => mod.instance_methods(false).map {|method| method_to_json(mod.instance_method(method))}.compact
       }

--- a/arg_scanner/lib/arg_scanner/state_tracker.rb
+++ b/arg_scanner/lib/arg_scanner/state_tracker.rb
@@ -54,49 +54,7 @@ module ArgScanner
     end
 
     def get_extra_methods(value)
-      begin
-       (value.methods - value.class.public_instance_methods).map do |method_name|
-           method = value.public_method(method_name)
-           method.owner
-       end.uniq
-      rescue Exception => e
-        value.methods - value.class.instance_methods
-      end
-
-    end
-
-    def get_constants_of_class(constants, parent, klass)
-        constants.select {|const| parent.const_defined?(const)}.map do |const|
-          begin
-            parent.const_get(const)
-          rescue Exception => e
-          end
-        end.select { |const| const.is_a? klass}
-    rescue => e
-      $stderr.puts(e)
-      []
-    end
-
-
-    def get_modules(mod)
-      get_constants_of_class(mod.constants, mod, Module)
-    end
-
-    def get_all_modules
-      queue = Queue.new
-      visited = Set.new
-      get_modules(Module).each {|mod| queue.push(mod); visited.add(mod)}
-
-      until queue.empty? do
-        mod = queue.pop
-        get_modules(mod).each do |child|
-          unless visited.include?(child)
-            queue.push(child)
-            visited.add(child)
-          end
-        end
-      end
-      visited
+      value.methods - value.public_methods
     end
 
     def method_to_json(method)
@@ -129,7 +87,7 @@ module ArgScanner
     end
 
     def modules_to_json
-      get_all_modules.map {|mod| module_to_json(mod)}.compact
+      ObjectSpace.each_object(Module).map {|mod| module_to_json(mod)}
     end
   end
 end

--- a/arg_scanner/test/test_state_tracker.rb
+++ b/arg_scanner/test/test_state_tracker.rb
@@ -32,8 +32,8 @@ class StateTrackerTest < Test::Unit::TestCase
     assert_not_nil(symbol)
     assert_equal(symbol["type"], "Class")
     assert_equal(symbol["superclass"], "Object")
-    assert_not_nil(symbol["singleton_class_included"].find_index("Kernel"))
-    assert_not_nil(symbol["included"].find_index("Comparable"))
+    assert_not_nil(symbol["singleton_class_ancestors"].find_index("Kernel"))
+    assert_not_nil(symbol["ancestors"].find_index("Comparable"))
     assert_not_nil(get_class_method(symbol, "all_symbols"))
     assert_not_nil(get_instance_method(symbol, "match"))
     parameters = get_instance_method(symbol, "match")['parameters']


### PR DESCRIPTION
Mainly removed implementation (which were based on included_modules) for the class structure traversing and replaced it with ObjectSpace's ancestors variant. Also made some refactoring for Kotlin code.